### PR TITLE
Return non-zero exit code on migration failures

### DIFF
--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -142,8 +142,7 @@ func (m *Migrator) Migrate(ctx context.Context, executionMode ExecutionMode) {
 		failuresCount, validationErrorsMsg := m.validate(ctx, instancesToMigrate, bindingsToMigrate)
 		if failuresCount > 0 {
 			fmt.Println(fmt.Sprintf("Validation failed got %d validation errors:", failuresCount))
-			fmt.Println(validationErrorsMsg.String())
-			return
+			cobra.CheckErr(validationErrorsMsg)
 		} else {
 			fmt.Println("*** Validation completed successfully")
 		}
@@ -175,7 +174,7 @@ func (m *Migrator) Migrate(ctx context.Context, executionMode ExecutionMode) {
 		fmt.Println("*** Migration completed successfully")
 	} else {
 		fmt.Println("*** Migration failures summary:")
-		fmt.Println(failuresBuffer.String())
+		cobra.CheckErr(failuresBuffer.String())
 	}
 }
 


### PR DESCRIPTION
The migration tool returns 1 on some failures but when the tool fails a little later in the algorithm to migrate some `ServiceInstances` or `ServiceBindings`, it will print an error but return 0.

I would like to propose a change to return 1 on any migration errors. This would simplify additional tooling to further automate migrations for managed environments.