### PR TITLE
Last resort to in cluster kubeconfig

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,6 +89,9 @@ func createOrOverrideConfig() {
 	kube := kubeconfig
 	if kube == "" {
 		kube = filepath.Join(homeDir(), ".kube", "config")
+		if _, err := os.Stat(kube); os.IsNotExist(err) {
+			kube = ""
+		}
 	}
 	ns := managedNamespace
 	if ns == "" {


### PR DESCRIPTION
For the migration of managed Kyma Runtimes, we would like to run the migration tool inside of the cluster as a `Job`. The `clientcmd.BuildConfigFromFlags()` can use `kubeconfig` path but also accepts `""`.
https://github.com/SAP/sap-btp-service-operator-migration/blob/025f55fecebd744a1c8cc26644fd94bdfbb1c5a8/migrate/migrator.go#L69
In case both arguments are empty, it tries to build inCluster config and issues following warning:
```
$ k logs sap-btp-operator-migration-qvlws
W0726 15:48:06.778712       1 client_config.go:614] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.
Migrator initialized with cluster ID 'd4b9a2e1-a2cf-4209-8c49-b438e16f087d'
*** Fetched 1 instances from SM
...
```
This is only a last resort when `-kubeconfig` was not provided and when the file `$HOME/.kube/config` does not exist.